### PR TITLE
Add CMake install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,42 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.14...3.25)
 
 project(aarand
     VERSION 1.0.0
     DESCRIPTION "Aaron's distribution functions"
     LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 11)
+include(GNUInstallDirs)
 
+# Library
 add_library(aarand INTERFACE)
+add_library(ltla::aarand ALIAS aarand)
 
-target_include_directories(aarand INTERFACE include/)
+target_include_directories(aarand INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ltla>)
+target_compile_features(aarand INTERFACE cxx_std_11)
 
+# Tests
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    option(AARAND_TESTS "" ON)
+else()
+    option(AARAND_TESTS "" OFF)
+endif()
+if(AARAND_TESTS)
     include(CTest)
     if(BUILD_TESTING)
         add_subdirectory(tests)
     endif()
 endif()
+
+# Install
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ltla)
+
+install(TARGETS aarand
+    EXPORT aarandTargets)
+
+install(EXPORT aarandTargets
+    FILE ltla_aarandConfig.cmake
+    NAMESPACE ltla::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ltla_aarand)


### PR DESCRIPTION
This is an extended version of the current CMake adding an install target including find_package() support, to give users an alternative to the FetchContent usage. This is also great for package managers such as vcpkg. Additionally, there is now an option to enable or disable tests.

If you like these changes, I have also prepared similar patches for powerit, CppKmeans, CppIrlba, knncolle and umappp. As all these small libraries belong together I though it may be practical to prefix the package names with ltla, use a common ltla install dir for the headers and use a ltla namespace on the CMake targets.

There should be no breaking changes to the FetchContent usage. The `AARAND_TESTS` option defaults to the previous behaviour and also using add_subdirectory() still has the old target names without namespace.